### PR TITLE
Remove depricated typing imports

### DIFF
--- a/pyplis/calib_base.py
+++ b/pyplis/calib_base.py
@@ -23,7 +23,7 @@ curves, and corresponding I/O routines (e.g storage as FITS or text file).
 from pyplis import logger
 from numpy import (min, asarray, zeros, linspace, ones, float64, isnan,
                    ndarray, argmax, inf)
-from inspect import getargspec
+from inspect import signature
 from scipy.optimize import curve_fit
 
 from datetime import datetime
@@ -170,7 +170,7 @@ class CalibData(object):
 
     def num_optargs_fun(self, fun):
         """Return number of optimisation args of a function."""
-        return len(getargspec(fun).args) - 1
+        return len(signature(fun).args) - 1
 
     @property
     def senscorr_mask(self):
@@ -230,7 +230,7 @@ class CalibData(object):
     def calib_fun(self, val):
         if not callable(val):
             raise ValueError("Need a callable object (e.g. lambda function)")
-        args = getargspec(val).args
+        args = signature(val).args
         logger.info("Setting optimisation function in CalibData class. "
                     "Argspec: %s" % args)
         self._calib_fun = val

--- a/pyplis/helpers.py
+++ b/pyplis/helpers.py
@@ -21,7 +21,7 @@ import matplotlib.colors as colors
 from datetime import datetime, time, date, timedelta
 
 from matplotlib.pyplot import draw
-from numpy import (mod, linspace, hstack, vectorize, uint8, cast, asarray,
+from numpy import (mod, linspace, hstack, vectorize, uint8, asarray,
                    log2, unravel_index, nanargmax, meshgrid, floor, log10,
                    isnan, argmin, sum, zeros, float32, ogrid)
 from scipy.ndimage import gaussian_filter
@@ -570,7 +570,7 @@ def bytescale(data, cmin=None, cmax=None, high=255, low=0):
     bytedata = (data * 1.0 - cmin) * scale + 0.4999
     bytedata[bytedata > high] = high
     bytedata[bytedata < 0] = 0
-    return cast[uint8](bytedata) + cast[uint8](low)
+    return bytearray.astype(uint8) + low.astype(uint8)
 
 
 if __name__ == "__main__":

--- a/pyplis/helpers.py
+++ b/pyplis/helpers.py
@@ -570,7 +570,7 @@ def bytescale(data, cmin=None, cmax=None, high=255, low=0):
     bytedata = (data * 1.0 - cmin) * scale + 0.4999
     bytedata[bytedata > high] = high
     bytedata[bytedata < 0] = 0
-    return bytearray.astype(uint8) + low.astype(uint8)
+    return bytedata.astype(uint8) + uint8(low)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
One unit-test fails, however this unit-test also fails in a python 3.9 environment.

Removing these depricated imports allows this module to be installed in 3.12
